### PR TITLE
Fix Subinspectors of ObjectInspector duplicates when creating an object before expanding the inspector.

### DIFF
--- a/JsonPowerInspector/Scripts/Inspectors/CollectionInspectors/CollectionInspector.cs
+++ b/JsonPowerInspector/Scripts/Inspectors/CollectionInspectors/CollectionInspector.cs
@@ -11,8 +11,8 @@ public abstract partial class CollectionInspector<TPropertyInfo> : BasePropertyI
     [Export] private Control _contentPanel;
     [Export] private Label _emptyIndicator;
     [Export] private CheckButton _foldout;
-    
-    private bool _created;
+
+    protected bool Created { get; private set; }
 
     protected virtual bool DisplayChildObjectByDefault => true;
 
@@ -47,9 +47,9 @@ public abstract partial class CollectionInspector<TPropertyInfo> : BasePropertyI
     {
         _foldout.Toggled += on =>
         {
-            if (!_created)
+            if (!Created)
             {
-                _created = true;
+                Created = true;
                 OnInitialPrint(GetBackingNode());
             }
             _contentPanel.Visible = on;

--- a/JsonPowerInspector/Scripts/Inspectors/CollectionInspectors/ObjectInspector.cs
+++ b/JsonPowerInspector/Scripts/Inspectors/CollectionInspectors/ObjectInspector.cs
@@ -27,7 +27,7 @@ public partial class ObjectInspector : CollectionInspector<ObjectPropertyInfo>
             {
                 var jsonObject = CreateDefaultJsonObject(PropertyInfo);
                 SetBackingNode(jsonObject);
-                BindObject(jsonObject);
+                if(Created) BindObject(jsonObject);
                 _createOrDeleteBtn.Text = "X";
             }
             CurrentSession.MarkChanged();


### PR DESCRIPTION
Before:
|![image](https://github.com/Delsin-Yu/Json-Power-Inspector/assets/71481700/88be750d-8dad-4ff4-a061-2930cba12573)|![image](https://github.com/Delsin-Yu/Json-Power-Inspector/assets/71481700/ddbb19ed-2678-4c77-bd91-0cb8928b6e9b)|
|-|-|

After:
|![image](https://github.com/Delsin-Yu/Json-Power-Inspector/assets/71481700/88be750d-8dad-4ff4-a061-2930cba12573)|![image](https://github.com/Delsin-Yu/Json-Power-Inspector/assets/71481700/630b622c-3c99-4a90-b848-d244b6ac0c17)|
|-|-|